### PR TITLE
Update runtime to Nodejs8.10 in CFn template

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@ This setup instruction is dedicated for OS X. You can probably follow these step
 ## Prerequisites
 
 - The latest version of the [AWS CLI](https://aws.amazon.com/cli/) to create AWS resources.
-- [Node.js](https://nodejs.org/) v4.3 or later to build web-app.
+- [Node.js](https://nodejs.org/) v6.10 or later to build web-app.
 
 We assume you are using an IAM Role/User with `AdministratorAccess`.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -5,7 +5,7 @@ This setup instruction is dedicated for OS X. You can probably follow these step
 ## Prerequisites
 
 - The latest version of the [AWS CLI](https://aws.amazon.com/cli/) to create AWS resources.
-- [Node.js](https://nodejs.org/) v6.10 or later to build web-app.
+- [Node.js](https://nodejs.org/) v8.10 or later to build web-app.
 
 We assume you are using an IAM Role/User with `AdministratorAccess`.
 

--- a/res/cfn/cognito.template
+++ b/res/cfn/cognito.template
@@ -123,7 +123,7 @@
         "Handler": "pingbot-cognito-deployer.handler",
         "MemorySize": 128,
         "Role": { "Fn::GetAtt": ["CognitoDeployerLambdaExecutionRole", "Arn"] },
-        "Runtime": "nodejs4.3",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },

--- a/res/cfn/lambda.template
+++ b/res/cfn/lambda.template
@@ -34,7 +34,7 @@
         "MemorySize": 128,
         "Handler": "pingbot-dispatcher.handler",
         "Role" : {"Ref" : "LambdaRoleArn" },
-        "Runtime" : "nodejs4.3",
+        "Runtime" : "nodejs8.10",
         "Timeout": 60
       }
     },
@@ -50,7 +50,7 @@
         "MemorySize": 128,
         "Handler": "pingbot-health-checker.handler",
         "Role" : {"Ref" : "LambdaRoleArn" },
-        "Runtime" : "nodejs4.3",
+        "Runtime" : "nodejs8.10",
         "Timeout": 55
       }
     },
@@ -66,7 +66,7 @@
         "MemorySize": 128,
         "Handler": "pingbot-result-processor.handler",
         "Role" : {"Ref" : "LambdaRoleArn" },
-        "Runtime" : "nodejs4.3",
+        "Runtime" : "nodejs8.10",
         "Timeout": 50
       }
     },
@@ -82,7 +82,7 @@
         "MemorySize": 128,
         "Handler": "pingbot-slack-notifier.handler",
         "Role" : {"Ref" : "LambdaRoleArn" },
-        "Runtime" : "nodejs4.3",
+        "Runtime" : "nodejs8.10",
         "Timeout": 50
       }
     },


### PR DESCRIPTION
In the current CloudFormation Tempate, Node.js 4.3 is specified at runtime. Therefore, it can not be deployed. I changed runtime to Node.js 8.10. No problem was found in simple test.