### PR TITLE
Update S3 template urls to allow USE1

### DIFF
--- a/res/cfn/main.template
+++ b/res/cfn/main.template
@@ -23,13 +23,13 @@
     "iam": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/iam.template"]] }
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/iam.template"]] }
       }
     },
     "dynamodb": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/dynamodb.template"]] },
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/dynamodb.template"]] },
         "Parameters": {
           "TargetsTableKeyName": "uuid",
           "TargetsTableKeyType": "S",
@@ -45,7 +45,7 @@
     "lambda": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/lambda.template"]] },
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/lambda.template"]] },
         "Parameters": {
           "LambdaRoleArn": { "Fn::GetAtt": [ "iam", "Outputs.PingbotLambdaRole" ] },
           "ArchiveBucketName": { "Ref": "TemplateBucketName" },
@@ -57,7 +57,7 @@
     "events": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/events.template"]] },
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/events.template"]] },
         "Parameters": {
           "LambdaDispatcherArn": { "Fn::GetAtt": [ "lambda", "Outputs.PingbotLambdaDispatcherArn" ] },
           "LambdaDispatcherFunctionName": { "Fn::GetAtt": [ "lambda", "Outputs.PingbotLambdaDispatcherName" ] }
@@ -67,13 +67,13 @@
     "logs": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/logs.template"]] }
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/logs.template"]] }
       }
     },
     "s3": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/s3.template"]] },
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/s3.template"]] },
         "Parameters": {
           "WebAppPermittedIPAddress": { "Ref": "WebAppPermittedIPAddress" }
         }
@@ -82,7 +82,7 @@
     "cognito": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
-        "TemplateURL": { "Fn::Join": ["", ["https://s3-", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/cognito.template"]] },
+        "TemplateURL": { "Fn::Join": ["", ["https://s3.", { "Ref": "AWS::Region" }, ".amazonaws.com/", { "Ref": "TemplateBucketName" }, "/cfn/cognito.template"]] },
         "Parameters": {
           "AllowUnauthenticatedIdentities": "true",
           "IdentityPoolName": "pingbotWeb",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -24,7 +24,7 @@ echo 'Creating CloudFormation stack...'
 aws cloudformation create-stack \
     --stack-name $STACK_NAME \
     --region $AWS_DEFAULT_REGION \
-    --template-url https://s3-$AWS_DEFAULT_REGION.amazonaws.com/$S3_PINGBOT_RESOURCE_BUCKET/cfn/main.template \
+    --template-url https://s3.$AWS_DEFAULT_REGION.amazonaws.com/$S3_PINGBOT_RESOURCE_BUCKET/cfn/main.template \
     --parameters ParameterKey=TemplateBucketName,ParameterValue=$S3_PINGBOT_RESOURCE_BUCKET \
                  ParameterKey=DeployTimestamp,ParameterValue=$TIMESTAMP \
                  ParameterKey=WebAppPermittedIPAddress,ParameterValue=$WEBAPP_PERMITTED_IP_ADDRESS \

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -24,7 +24,7 @@ echo 'Updating CloudFormation stack...'
 aws cloudformation update-stack \
     --stack-name $STACK_NAME \
     --region $AWS_DEFAULT_REGION \
-    --template-url https://s3-$AWS_DEFAULT_REGION.amazonaws.com/$S3_PINGBOT_RESOURCE_BUCKET/cfn/main.template \
+    --template-url https://s3.$AWS_DEFAULT_REGION.amazonaws.com/$S3_PINGBOT_RESOURCE_BUCKET/cfn/main.template \
     --parameters ParameterKey=TemplateBucketName,ParameterValue=$S3_PINGBOT_RESOURCE_BUCKET \
                  ParameterKey=DeployTimestamp,ParameterValue=$TIMESTAMP \
                  ParameterKey=WebAppPermittedIPAddress,ParameterValue=$WEBAPP_PERMITTED_IP_ADDRESS \


### PR DESCRIPTION
Allows deployment to `us-east-1` using proper [regional endpoint](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints) url. Looks like the URL structure may have changed at some point in the past. The `<service-name>-<region>.amazonaws.com` urls currently work for other regions, but not for USE1 -- perhaps because it is the default region?